### PR TITLE
Added feature for static linking

### DIFF
--- a/basis-universal-sys/Cargo.toml
+++ b/basis-universal-sys/Cargo.toml
@@ -19,4 +19,3 @@ cc = "1.0"
 
 [features]
 link-static = []
-with-sse = []

--- a/basis-universal-sys/Cargo.toml
+++ b/basis-universal-sys/Cargo.toml
@@ -16,3 +16,7 @@ exclude = ["vendor/basis_universal/test_files", "vendor/basis_universal/webgl", 
 
 [build-dependencies]
 cc = "1.0"
+
+[features]
+link-static = []
+with-sse = []

--- a/basis-universal-sys/build.rs
+++ b/basis-universal-sys/build.rs
@@ -17,8 +17,11 @@ fn build_with_common_settings() -> cc::Build {
 fn main() {
     build_with_common_settings()
         .cpp(true)
-        .define("BASISD_SUPPORT_KTX2_ZSTD", "0")
-        //.define("BASISU_SUPPORT_SSE", "1") TODO: expose this in a futher release
+        .define("BASISD_SUPPORT_KTX2_ZSTD", if cfg!(feature = "with-zstd") {"1"} else {"0"})
+        .define("BASISU_SUPPORT_SSE", if cfg!(feature = "with-SSE") {"1"} else {"0"}) // TODO: expose this in a futher release
+        .cpp_link_stdlib_static(cfg!(feature = "link-static"))
+        .static_crt(cfg!(feature = "link-static"))
+        .static_flag(cfg!(feature = "link-static"))
         .flag_if_supported("--std=c++11")
         .file("vendor/basis_universal/encoder/pvpngreader.cpp")
         .file("vendor/basis_universal/encoder/jpgd.cpp")

--- a/basis-universal-sys/build.rs
+++ b/basis-universal-sys/build.rs
@@ -17,8 +17,8 @@ fn build_with_common_settings() -> cc::Build {
 fn main() {
     build_with_common_settings()
         .cpp(true)
-        .define("BASISD_SUPPORT_KTX2_ZSTD", if cfg!(feature = "with-zstd") {"1"} else {"0"})
-        .define("BASISU_SUPPORT_SSE", if cfg!(feature = "with-SSE") {"1"} else {"0"}) // TODO: expose this in a futher release
+        .define("BASISD_SUPPORT_KTX2_ZSTD", "0")
+        //.define("BASISU_SUPPORT_SSE", "0") TODO: expose this in a futher release
         .cpp_link_stdlib_static(cfg!(feature = "link-static"))
         .static_crt(cfg!(feature = "link-static"))
         .static_flag(cfg!(feature = "link-static"))

--- a/basis-universal/Cargo.toml
+++ b/basis-universal/Cargo.toml
@@ -22,4 +22,3 @@ lz4 = "1.23"
 
 [features]
 link-static = ["basis-universal-sys/link-static"]
-with-sse = ["basis-universal-sys/with-sse"]

--- a/basis-universal/Cargo.toml
+++ b/basis-universal/Cargo.toml
@@ -19,3 +19,7 @@ bitflags = "1.2.1"
 [dev-dependencies]
 image = "0.23.13"
 lz4 = "1.23"
+
+[features]
+link-static = ["basis-universal-sys/link-static"]
+with-sse = ["basis-universal-sys/with-sse"]


### PR DESCRIPTION
I was running into some issues due to linking statically with a different library (Assimp). 
Specifically this error
```
error: linking with `link.exe` failed: exit code: 1169
  |
  = note: "C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\VC\\Tools\\MSVC\\14.43.34808\\bin\\HostX64\\x64\\link.exe" "/NOLOGO" "C:\\Users\\Manuel\\AppData\\Local\\Temp\\rustcQVjgDL\\symbols.o" "<257 object files omitted>" ...
  = note: some arguments are omitted. use `--verbose` to show all linker arguments
  = note: librussimp_sys-cddc1b1b36611906.rlib(Assimp.obj) : error LNK2038: mismatch detected for 'RuntimeLibrary': value 'MT_StaticRelease' doesn't match value 'MD_DynamicRelease' in libbasis_universal_sys-11b0d89a5f73da7e.rlib(18c57188dd651d14-encoding_wrapper.o)␍
  <further similar errors omitted>
```

To fix thisI introduced a new feature for linking statically with the library.